### PR TITLE
Remove dependency on separate mock package

### DIFF
--- a/pyls_spyder/tests/test_plugin.py
+++ b/pyls_spyder/tests/test_plugin.py
@@ -17,7 +17,7 @@ from pyls.workspace import Document
 
 # pytest imports
 import pytest
-from mock import MagicMock
+from unittest.mock import MagicMock
 
 # Local imports
 from pyls_spyder.plugin import pyls_document_symbols


### PR DESCRIPTION
You can use unittest.mock from the standard library directly in Python >3.3, no need to depend on the package